### PR TITLE
Removed gpg plugin from topmost <build>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,20 +82,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.4</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>
         <executions>


### PR DESCRIPTION
I'm not 100% sure about this one, but I've never seen a project use the gpg-plugin outside of an actual release.

I noticed because I was asked to sign the JAR during a `mvn install`, which doesn't seem necessary.

As a side note, you might consider using sonatype's OSS parent POM, which handles a bunch of boilerplate.