### PR TITLE
Add InstantConverter to Converters

### DIFF
--- a/src/main/java/com/fatboyindustrial/gsonjavatime/Converters.java
+++ b/src/main/java/com/fatboyindustrial/gsonjavatime/Converters.java
@@ -27,6 +27,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -58,6 +59,9 @@ public class Converters
   /** The specific genericized type for {@code ZonedDateTime}. */
   public static final Type ZONED_DATE_TIME_TYPE = new TypeToken<ZonedDateTime>(){}.getType();
 
+  /** The specific genericized type for {@code Instant}. */
+  public static final Type INSTANT_TYPE = new TypeToken<Instant>(){}.getType();
+
   /**
    * Registers all the Java Time converters.
    * @param builder The GSON builder to register the converters with.
@@ -73,6 +77,7 @@ public class Converters
     registerOffsetDateTime(builder);
     registerOffsetTime(builder);
     registerZonedDateTime(builder);
+    registerInstant(builder);
 
     return builder;
   }
@@ -146,6 +151,13 @@ public class Converters
   {
     builder.registerTypeAdapter(ZONED_DATE_TIME_TYPE, new ZonedDateTimeConverter());
 
+    return builder;
+  }
+  
+  public static GsonBuilder registerInstant(GsonBuilder builder)
+  {
+    builder.registerTypeAdapter(INSTANT_TYPE, new InstantConverter());
+    
     return builder;
   }
 }

--- a/src/test/java/com/fatboyindustrial/gsonjavatime/ConvertersTest.java
+++ b/src/test/java/com/fatboyindustrial/gsonjavatime/ConvertersTest.java
@@ -25,7 +25,10 @@ package com.fatboyindustrial.gsonjavatime;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -36,6 +39,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -44,13 +48,14 @@ import static org.junit.Assert.assertThat;
  */
 public class ConvertersTest
 {
+  private final Gson gson = Converters.registerAll(new GsonBuilder()).create();
+  
   /**
    * Tests that the {@link Converters#registerAll} method registers the converters successfully.
    */
   @Test
   public void testRegisterAll()
   {
-    final Gson gson = Converters.registerAll(new GsonBuilder()).create();
     final Container original = new Container();
     original.ld = LocalDate.now();
     original.ldt = LocalDateTime.now();
@@ -69,6 +74,63 @@ public class ConvertersTest
     assertThat(reconstituted.ot, is(original.ot));
     assertThat(reconstituted.zdt, is(original.zdt));
     assertThat(reconstituted.i, is(original.i));
+  }
+  
+  @Test
+  public void testSerialization() throws Exception
+  {
+    Container container = new Container();
+    container.ld = LocalDate.now();
+    container.ldt = LocalDateTime.now();
+    container.lt = LocalTime.now();
+    container.odt = OffsetDateTime.now();
+    container.ot = OffsetTime.now();
+    container.zdt = ZonedDateTime.now();
+    container.i = Instant.now();
+    
+    String jsonString = gson.toJson(container);
+    JsonObject json = gson.fromJson(jsonString, JsonObject.class).getAsJsonObject();
+    
+    assertThat(json.get("ld").getAsString(), Matchers.equalTo(container.ld.toString()));
+    assertThat(json.get("ldt").getAsString(), Matchers.equalTo(container.ldt.toString()));
+    assertThat(json.get("lt").getAsString(), Matchers.equalTo(container.lt.toString()));
+    assertThat(json.get("odt").getAsString(), Matchers.equalTo(container.odt.toString()));
+    assertThat(json.get("ot").getAsString(), Matchers.equalTo(container.ot.toString()));
+    assertThat(json.get("zdt").getAsString(), Matchers.equalTo(container.zdt.toString()));
+    assertThat(json.get("i").getAsString(), Matchers.equalTo(container.i.toString()));
+  }
+  
+  @Test
+  public void testDeserialization() throws Exception
+  {
+    Container container = new Container();
+    container.ld = LocalDate.now();
+    container.ldt = LocalDateTime.now();
+    container.lt = LocalTime.now();
+    container.odt = OffsetDateTime.now();
+    container.ot = OffsetTime.now();
+    container.zdt = ZonedDateTime.now();
+    container.i = Instant.now();
+    
+    JsonObject serialized = new JsonObject();
+    serialized.add("ld", new JsonPrimitive(container.ld.toString()));
+    serialized.add("ldt", new JsonPrimitive(container.ldt.toString()));
+    serialized.add("lt", new JsonPrimitive(container.lt.toString()));
+    serialized.add("odt", new JsonPrimitive(container.odt.toString()));
+    serialized.add("ot", new JsonPrimitive(container.ot.toString()));
+    serialized.add("zdt", new JsonPrimitive(container.zdt.toString()));
+    serialized.add("i", new JsonPrimitive(container.i.toString()));
+
+    String jsonString = gson.toJson(serialized);
+    Container deserialized = gson.fromJson(jsonString, Container.class);
+    
+    assertThat(deserialized.ld, equalTo(container.ld));
+    assertThat(deserialized.ldt, equalTo(container.ldt));
+    assertThat(deserialized.lt, equalTo(container.lt));
+    assertThat(deserialized.odt, equalTo(container.odt));
+    assertThat(deserialized.ot, equalTo(container.ot));
+    assertThat(deserialized.zdt, equalTo(container.zdt));
+    assertThat(deserialized.i, equalTo(container.i));
   }
 
   /**

--- a/src/test/java/com/fatboyindustrial/gsonjavatime/InstantConverterTest.java
+++ b/src/test/java/com/fatboyindustrial/gsonjavatime/InstantConverterTest.java
@@ -2,6 +2,7 @@ package com.fatboyindustrial.gsonjavatime;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonPrimitive;
 
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class InstantConverterTest
   public void should_deserialise_from_iso_instant() throws Exception
   {
     Instant now = Instant.now();
-    Instant fromJson = gson.fromJson(gson.toJson(now), Instant.class);
+    Instant fromJson = gson.fromJson(new JsonPrimitive(now.toString()), Instant.class);
     
     assertThat(fromJson, equalTo(now));
   }


### PR DESCRIPTION
I was trying to use the library in a project and realised I'd forgotten to add the InstantConverter to `Converters.registerAll()`... Sorry!

Also, I added 2 tests to ConvertersTest that actually fail if the converters are not registered. That was not the case for any of the existing tests. I modified InstantConverterTest as an example of how the other tests could be modified to fail if the Converter is not registered. However, it's not strictly necessary, as I believe ConvertersTest now covers all cases: serialising and deserialising.